### PR TITLE
Revert "Remove the menu item, Sync Civi Contacts to Mailchimp"

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -412,6 +412,18 @@ function mailchimp_civicrm_navigationMenu(&$params){
           'permission'=> 'administer CiviCRM',
         ),
   );
+  $params[$parentId]['child'][$mailChimpsyncId] = array(
+        'attributes' => array(
+          'label'     => ts('Sync Civi Contacts To Mailchimp'),
+          'name'      => 'Mailchimp_Sync',
+          'url'       => CRM_Utils_System::url('civicrm/mailchimp/sync', 'reset=1', TRUE),
+          'active'    => 1,
+          'parentID'  => $parentId,
+          'operator'  => NULL,
+          'navID'     => $mailChimpsyncId,
+          'permission'=> 'administer CiviCRM,allow Mailchimp sync',
+        ),
+  );
   $params[$parentId]['child'][$mailChimpPullId] = array(
         'attributes' => array(
           'label'     => ts('Sync Mailchimp Contacts To Civi‏'),


### PR DESCRIPTION
Reverts veda-consulting-company/uk.co.vedaconsulting.mailchimp#333
Mailchimp has changed it so that once a contact has been unsubscribed they cannot be re-subscribed.
The push sync unsubscribes contacts that are not in the CiviCRM group that is mapped to a Mailchimp audience. 
To avoid accidental and irreversible unsubscribes, the push sync  will  be retained but changed so it no longer unsubscribes contacts.  