### PR TITLE
Revert "Remove unused jobs"

### DIFF
--- a/CRM/Mailchimp/Upgrader.php
+++ b/CRM/Mailchimp/Upgrader.php
@@ -227,21 +227,6 @@ class CRM_Mailchimp_Upgrader extends CRM_Mailchimp_Upgrader_Base {
 
     return TRUE;
   }
-
-  /**
-   * Remove unused jobs
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function upgrade_22() {
-    $result = civicrm_api3('Job', 'get', [
-      'sequential' => 1,
-      'name' => ['IN' => ["Mailchimp Push Sync", "Mailchimp Pull Sync"]],
-      'api.Job.delete' => ['id' => "\$value.id"],
-    ]);
-
-    return TRUE;
-  }
   /**
    * Example: Run an external SQL script
    *

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -34,6 +34,32 @@ function mailchimp_civicrm_xmlMenu(&$files) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
  */
 function mailchimp_civicrm_install() {
+
+  // Create a cron job to do sync data between CiviCRM and MailChimp.
+  $params = array(
+    'sequential' => 1,
+    'name'          => 'Mailchimp Push Sync',
+    'description'   => 'Sync contacts between CiviCRM and MailChimp, assuming CiviCRM to be correct. Please understand the implications before using this.',
+    'run_frequency' => 'Daily',
+    'api_entity'    => 'Mailchimp',
+    'api_action'    => 'pushsync',
+    'is_active'     => 0,
+  );
+  $result = civicrm_api3('job', 'create', $params);
+  
+
+  // Create Pull Sync job.
+  $params = array(
+    'sequential' => 1,
+    'name'          => 'Mailchimp Pull Sync',
+    'description'   => 'Sync contacts between CiviCRM and MailChimp, assuming Mailchimp to be correct. Please understand the implications before using this.',
+    'run_frequency' => 'Daily',
+    'api_entity'    => 'Mailchimp',
+    'api_action'    => 'pullsync',
+    'is_active'     => 0,
+  );
+  $result = civicrm_api3('job', 'create', $params);
+
   return _mailchimp_civix_civicrm_install();
 }
 


### PR DESCRIPTION
Reverts veda-consulting-company/uk.co.vedaconsulting.mailchimp#332

Mailchimp has changed it so that once a contact has been unsubscribed they cannot be re-subscribed.
The push sync unsubscribes contacts that are not in the CiviCRM group that is mapped to a Mailchimp audience.
To avoid accidental and irreversible unsubscribes, the push sync will be retained but changed so it no longer unsubscribes contacts.
The jobs are by default not active so should not cause any surprises if dry-runs are performed before enabling them.