### PR TITLE
Tag sync fixes & Hook to modify collected Civi date for sync

### DIFF
--- a/CRM/Mailchimp/Check.php
+++ b/CRM/Mailchimp/Check.php
@@ -334,6 +334,7 @@ class CRM_Mailchimp_Check {
       return FALSE;
     }
     CRM_Core_DAO::executeQuery( "DROP TABLE IF EXISTS $tableName;");
+    $tempTableSchema = CRM_Mailchimp_Utils::getTempTableSchema();
     $dao = CRM_Core_DAO::executeQuery(
     "CREATE TABLE $tableName (
         contact_id INT(10) NOT NULL,
@@ -346,7 +347,7 @@ class CRM_Mailchimp_Check {
         is_opt_out TINYINT DEFAULT 0,
         PRIMARY KEY (contact_id),
         KEY (email))
-        ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ;");
+        ENGINE=InnoDB DEFAULT CHARACTER SET {$tempTableSchema} ;");
      return $dao;
   }
   

--- a/CRM/Mailchimp/Sync.php
+++ b/CRM/Mailchimp/Sync.php
@@ -424,6 +424,10 @@ class CRM_Mailchimp_Sync {
           $contact_custom[$tag] = $contact[$name];
         }
       }
+
+      // Allow hook to modify data before inserted into the temp table
+      CRM_Mailchimp_Utils_Hook::alterCiviDataforMailchimp($contact['id'], $email, $contact, $contact_custom);
+
       $custom_data = $contact_custom ? serialize($contact_custom) : '';
 
       $tags = $contact['tags'] ? serialize($contact['tags']) : '';

--- a/CRM/Mailchimp/Sync.php
+++ b/CRM/Mailchimp/Sync.php
@@ -1735,7 +1735,7 @@ class CRM_Mailchimp_Sync {
         tags VARCHAR(4096) NOT NULL DEFAULT '',
         PRIMARY KEY (email, hash),
         KEY (cid_guess))
-        ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;");
+        ENGINE=InnoDB;");
 
     // Convenience in collectMailchimp.
     return $dao;
@@ -1767,7 +1767,7 @@ class CRM_Mailchimp_Sync {
         PRIMARY KEY (email, hash),
         KEY (contact_id)
         )
-        ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ;");
+        ENGINE=InnoDB;");
     return $dao;
   }
   /**

--- a/CRM/Mailchimp/Sync.php
+++ b/CRM/Mailchimp/Sync.php
@@ -1724,6 +1724,7 @@ class CRM_Mailchimp_Sync {
    */
   public static function createTemporaryTableForMailchimp() {
     CRM_Core_DAO::executeQuery( "DROP TABLE IF EXISTS tmp_mailchimp_push_m;");
+    $tempTableSchema = CRM_Mailchimp_Utils::getTempTableSchema();
     $dao = CRM_Core_DAO::executeQuery(
       "CREATE TABLE tmp_mailchimp_push_m (
         email VARCHAR(200) NOT NULL,
@@ -1743,7 +1744,7 @@ class CRM_Mailchimp_Sync {
         tags VARCHAR(4096) NOT NULL DEFAULT '',
         PRIMARY KEY (email, hash),
         KEY (cid_guess))
-        ENGINE=InnoDB;");
+        ENGINE=InnoDB DEFAULT CHARACTER SET {$tempTableSchema};");
 
     // Convenience in collectMailchimp.
     return $dao;
@@ -1756,6 +1757,7 @@ class CRM_Mailchimp_Sync {
    */
   public static function createTemporaryTableForCiviCRM() {
     CRM_Core_DAO::executeQuery( "DROP TABLE IF EXISTS tmp_mailchimp_push_c;");
+    $tempTableSchema = CRM_Mailchimp_Utils::getTempTableSchema();
     $dao = CRM_Core_DAO::executeQuery("CREATE TABLE tmp_mailchimp_push_c (
         contact_id INT(10) UNSIGNED NOT NULL,
         email VARCHAR(200) NOT NULL,
@@ -1775,7 +1777,7 @@ class CRM_Mailchimp_Sync {
         PRIMARY KEY (email, hash),
         KEY (contact_id)
         )
-        ENGINE=InnoDB;");
+        ENGINE=InnoDB DEFAULT CHARACTER SET {$tempTableSchema};");
     return $dao;
   }
   /**

--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -684,5 +684,28 @@ class CRM_Mailchimp_Utils {
       CRM_Utils_System::civiExit();
     }
     return $randomWebhookKey;
-  }  
+  }
+
+  /**
+   * Get temp table schema
+   *
+   * @return collation & characterSet
+   */
+  public static function getTempTableSchema() {
+    $collation = 'utf8_unicode_ci';
+    $characterSet = 'utf8';
+
+    // check if getInUseCollation() exists and get the collation is use
+    if (method_exists(CRM_Core_BAO_SchemaHandler::class, 'getInUseCollation')) {
+      $collation = CRM_Core_BAO_SchemaHandler::getInUseCollation();
+    }
+    // check if getDBCharset() exists and get the Charset is use
+    if (method_exists(CRM_Core_BAO_SchemaHandler::class, 'getDBCharset')) {
+      $characterSet = CRM_Core_BAO_SchemaHandler::getDBCharset();
+    }
+
+    $tempTableSchema = "{$characterSet} COLLATE {$collation}";
+
+    return $tempTableSchema;
+  }
 }

--- a/CRM/Mailchimp/Utils/Hook.php
+++ b/CRM/Mailchimp/Utils/Hook.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ *
+ * @package CiviCRM_Hook
+ * @copyright CiviCRM LLC (c) 2004-2011
+ * $Id: $
+ *
+ */
+
+abstract class CRM_Mailchimp_Utils_Hook {
+
+  static $_nullObject = null;
+
+  /**
+   * We only need one instance of this object. So we use the singleton
+   * pattern and cache the instance in this variable
+   *
+   * @var object
+   * @static
+   */
+  static private $_singleton = null;
+
+
+  /**
+   * Constructor and getter for the singleton instance
+   * @return instance of $config->userHookClass
+   */
+  static function singleton( ) {
+    if (self::$_singleton == null) {
+      $config = CRM_Core_Config::singleton( );
+      $class = $config->userHookClass;
+      require_once( str_replace( '_', DIRECTORY_SEPARATOR, $config->userHookClass ) . '.php' );
+      self::$_singleton = new $class();
+    }
+    return self::$_singleton;
+  }
+
+  abstract function invoke( $numParams,
+                            &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
+                            $fnSuffix );
+
+  /**
+   * This hook allows to modify collected CiviData for Mailchimp sync
+   * @param integer $contactID  contact being checked
+   * @param string $email
+   * @param array $contactData
+   * @param array $contactCustomData
+   *
+   * @access public
+   */
+  static function alterCiviDataforMailchimp ($contactID,  $email, &$contactData, &$contactCustomData) {
+    return self::singleton( )->invoke( 4, $contactID, $email, $contactData, $contactCustomData, self::$_nullObject, self::$_nullObject, 'civicrm_alterCiviDataforMailchimp');
+  }
+}


### PR DESCRIPTION
- Fixed collate issue on temp tables 
- Sync tags even if there's no change in other fields
- Allow hook to modify collected CiviCRM data for sync