### PR TITLE
Prevent duplicate rows db error while collecting Mailchimp data

### DIFF
--- a/CRM/Mailchimp/Sync.php
+++ b/CRM/Mailchimp/Sync.php
@@ -151,6 +151,8 @@ class CRM_Mailchimp_Sync {
     //
     // Main loop of all the records.
     $collected = 0;
+    // Note hashes being inserted to prevent db duplicate errors.
+    $hashes = [];
     while ($members = $fetch_batch()) {
       $start = microtime(TRUE);
       foreach ($members as $member) {
@@ -220,6 +222,13 @@ class CRM_Mailchimp_Sync {
         // email. So we don't count an email mismatch as a problem.
         // $hash = md5($member->email_address . $first_name . $last_name . $interests);
         $hash = md5($first_name . $last_name . $interests);
+        // Prevent duplicate rows db error.
+        if (!empty($hashes[$hash])) {
+          continue;
+        } else {
+          $hashes[$hash] = 1;
+        }
+
         // run insert prepared statement
         $result = $db->execute($insert, [
           $member->email_address,

--- a/CRM/Mailchimp/Utils/Hook.php
+++ b/CRM/Mailchimp/Utils/Hook.php
@@ -50,6 +50,13 @@ abstract class CRM_Mailchimp_Utils_Hook {
    * @access public
    */
   static function alterCiviDataforMailchimp ($contactID,  $email, &$contactData, &$contactCustomData) {
-    return self::singleton( )->invoke( 4, $contactID, $email, $contactData, $contactCustomData, self::$_nullObject, self::$_nullObject, 'civicrm_alterCiviDataforMailchimp');
+    $civiVersion = CRM_Core_BAO_Domain::version();
+    //from CiviCRM 5.0 the invoke function expects array of parameter names as first param
+    if (version_compare($civiVersion, '5.0', '<')) {
+      $numParams = 4;
+    } else {
+      $numParams = array('contactID', 'email', 'contactData', 'contactCustomData');
+    }
+    return self::singleton( )->invoke( $numParams, $contactID, $email, $contactData, $contactCustomData, self::$_nullObject, self::$_nullObject, 'civicrm_alterCiviDataforMailchimp');
   }
 }


### PR DESCRIPTION
- Prevent duplicate rows db error while collecting Mailchimp data
- Fixed deprecated warning in custom hook invoke 